### PR TITLE
GS-487: Space tests

### DIFF
--- a/appoptics/resource_appoptics_space_test.go
+++ b/appoptics/resource_appoptics_space_test.go
@@ -24,7 +24,6 @@ func TestAccAppOpticsSpaceBasic(t *testing.T) {
 				Config: testAccCheckAppOpticsSpaceConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppOpticsSpaceExists("appoptics_space.foobar", &space),
-					testAccCheckAppOpticsSpaceAttributes(&space, name),
 					resource.TestCheckResourceAttr(
 						"appoptics_space.foobar", "name", name),
 				),
@@ -53,17 +52,6 @@ func testAccCheckAppOpticsSpaceDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAppOpticsSpaceAttributes(space *appoptics.Space, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		if space.Name == "" || space.Name != name {
-			return fmt.Errorf("Bad name: %s", space.Name)
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckAppOpticsSpaceExists(n string, space *appoptics.Space) resource.TestCheckFunc {


### PR DESCRIPTION
This gets all of the Space tests passing:

```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAppOpticsAlertMinimal
--- PASS: TestAccAppOpticsAlertMinimal (0.97s)
=== RUN   TestAccAppOpticsAlertBasic
--- PASS: TestAccAppOpticsAlertBasic (0.85s)
=== RUN   TestAccAppOpticsAlertFull
--- PASS: TestAccAppOpticsAlertFull (4.69s)
=== RUN   TestAccAppOpticsAlertUpdated
--- PASS: TestAccAppOpticsAlertUpdated (9.64s)
=== RUN   TestAccAppOpticsAlertRename
--- PASS: TestAccAppOpticsAlertRename (9.46s)
=== RUN   TestAccAppOpticsAlertFullUpdate
--- PASS: TestAccAppOpticsAlertFullUpdate (3.74s)
=== RUN   TestAccAppOpticsServiceBasic
--- PASS: TestAccAppOpticsServiceBasic (3.60s)
=== RUN   TestAccAppOpticsServiceUpdated
--- PASS: TestAccAppOpticsServiceUpdated (14.01s)
=== RUN   TestAccAppOpticsSpaceBasic
--- PASS: TestAccAppOpticsSpaceBasic (0.84s)
```
