### PR TITLE
Fix for Issue#59 - unable to modify runbook_url

### DIFF
--- a/appoptics/resource_appoptics_alert.go
+++ b/appoptics/resource_appoptics_alert.go
@@ -474,12 +474,11 @@ func resourceAppOpticsAlertUpdate(d *schema.ResourceData, meta interface{}) erro
 	alert.Conditions = conditions
 
 	if d.HasChange("attributes") {
-		attributeData := d.Get("attributes").([]interface{})
-		if attributeData[0] == nil {
+		attributeData := d.Get("attributes").(map[string]interface{})
+		if len(attributeData) == 0 {
 			return fmt.Errorf("No attributes found in attributes block")
 		}
-
-		alert.Attributes = attributeData[0].(map[string]interface{})
+		alert.Attributes = attributeData
 	}
 
 	log.Printf("[INFO] Updating AppOptics alert: %s", alert.Name)


### PR DESCRIPTION
Unfortunately I haven't found a way to remove runbook_url. AO API seems to ignore 'attributes:{}' so ... once runbook_url is added it will stay forever - it can be only set to empty string.